### PR TITLE
'ATEM マニュアル' 'Multi View' の表記を統一

### DIFF
--- a/docs/pages/atem-tv-st/custom-multiview.md
+++ b/docs/pages/atem-tv-st/custom-multiview.md
@@ -1,21 +1,21 @@
-# Multi view をカスタマイズする
+# Multi View をカスタマイズする
 
 ![Author](https://img.shields.io/badge/Author-aKuad-brightgreen)
 ![Created date](https://img.shields.io/badge/Created-2023%2F09%2F02-blue)
 ![Last Modified date](https://img.shields.io/badge/Last%20Modified-2023%2F09%2F02-blue)
 
-使用する映像入力によっては、デフォルトの Multi view 表示が不便なことがあります。
-Multi view の内容は PC (ATEM Software Control) から変更でき、必要な映像を表示するようにしたり、表示名を変更したりできます。
+使用する映像入力によっては、デフォルトの Multi View 表示が不便なことがあります。
+Multi View の内容は PC (ATEM Software Control) から変更でき、必要な映像を表示するようにしたり、表示名を変更したりできます。
 
 まずは ATEM Software Control 画面左下の歯車アイコンから設定を開きます。
 
 ![ATEM Software Control - Config](./media/atem-sc-config.webp ':size=700')
 
-設定の 'マルチビュー' タブから、Multi view に表示する映像や配置を変更できます。
+設定の 'マルチビュー' タブから、Multi View に表示する映像や配置を変更できます。
 
-![Multi view - Position](./media/multiview-position.webp ':size=500')
+![Multi View - Position](./media/multiview-position.webp ':size=500')
 
 また、'ラベル' タブから各映像入出力の表示名を変更できます。
-'名前' 欄に設定した文字列は Multi view に反映されます。
+'名前' 欄に設定した文字列は Multi View に反映されます。
 
-![Multi view - Label](./media/multiview-lavel.webp ':size=500')
+![Multi View - Label](./media/multiview-lavel.webp ':size=500')

--- a/docs/pages/atem-tv-st/video-composite.md
+++ b/docs/pages/atem-tv-st/video-composite.md
@@ -68,13 +68,13 @@ KEY 1 を有効化すると、Preview に Upstream Key が適用されます。
 
 ![USK Preview - Software control](./media/usk-preview-sc.webp)
 
-![USK Preview - Multi view](./media/usk-preview-view.webp ':size=700')
+![USK Preview - Multi View](./media/usk-preview-view.webp ':size=700')
 
 この状態でスイッチすれば、Program に反映されます。
 
 ![USK Program - Software control](./media/usk-program-sc.webp)
 
-![USK Program - Multi view](./media/usk-program-view.webp ':size=700')
+![USK Program - Multi View](./media/usk-program-view.webp ':size=700')
 
 ### パターン合成
 

--- a/docs/pages/atem-tv-st/video-terms-and-io.md
+++ b/docs/pages/atem-tv-st/video-terms-and-io.md
@@ -27,9 +27,9 @@ AUX は、各入力や出力から任意の映像を 1つ選んで出力でき�
 MULTI-VIEW は、各入力、Preview、Program を 1画面で確認できる出力です。
 この画面を見ながら操作をするのが基本です。
 
-![ATEM Multi view](./media/atem-multi-view.webp ':size=700')
+![ATEM Multi View](./media/atem-multi-view.webp ':size=700')
 
-?> Multi view の映像配置は[変更することができます](./custom-multiview.md)。
+?> Multi View の映像配置は[変更することができます](./custom-multiview.md)。
 
 映像入力から出力までを図にすると、以下のようになります。
 


### PR DESCRIPTION
'Multi view' から 'Multi View' へ。

ソフトの英語表示や公式ページの表記が後者だったため。